### PR TITLE
Remove codeowners for test repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @felipebalbi @jerrysxie @tullom @RobertZ2011


### PR DESCRIPTION
This is a temporary repository to test new Github actions to check permissions and avoid breaking builds on other repositories.
Removing codeowners populated by the template to avoid unnecessary notifications.